### PR TITLE
Bugfix : Fix build error in web

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -100,12 +100,12 @@ packages:
     source: hosted
     version: "3.3.8"
   firebase_core:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.12.0"
+    version: "1.13.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -177,6 +177,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -244,7 +251,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -260,5 +267,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   firebase_analytics: ^9.1.1
   firebase_auth: ^3.3.8
+  firebase_core: ^1.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Upgrade firebase-core version 12.0 to 13.0

**Problem**
![image](https://user-images.githubusercontent.com/50590025/155713823-52532d49-650f-425a-af03-5c5de15f6e6d.png)

**Cause**
guardWebExceptions function is declared in `v1.12.0`

It is updated in [`v1.13.0`](https://github.com/FirebaseExtended/flutterfire/commit/593adc6cb210ffe03c6f18bba2f2a6478c1a8dd4)

**firebase_core-v1.12.0**
https://github.com/FirebaseExtended/flutterfire/blob/firebase_core-v1.12.0/packages/firebase_core/firebase_core/lib/src/internals.dart#L80-L85

**firebase_core-v1.13.0**
https://github.com/FirebaseExtended/flutterfire/blob/firebase_core-v1.13.0/packages/firebase_core/firebase_core/lib/src/internals.dart#L80-L85

