### PR TITLE
Setup repository server ip for emulate device.

### DIFF
--- a/fitqa_flutter/lib/src/data/repositories/fitqa_repository.dart
+++ b/fitqa_flutter/lib/src/data/repositories/fitqa_repository.dart
@@ -1,11 +1,13 @@
+import 'package:dio/dio.dart';
 import 'package:fitqa/src/common/exceptions.dart';
 import 'package:fitqa/src/data/dtos/trainer/get_trainers_response/get_trainers_response.dart';
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:dio/dio.dart';
 
+const serverIP = (kIsWeb) ? '127.0.0.1' : '10.0.2.2';
 final clientProvider = Provider(
-    (ref) => Dio(BaseOptions(baseUrl: 'http://localhost:8080/api/v1')));
+    (ref) => Dio(BaseOptions(baseUrl: 'http://$serverIP:8080/api/v1')));
 
 final fitQaRepositoryProvider =
     Provider<FitQaRepositoryApi>((ref) => FitQaRepositoryApi(ref.read));


### PR DESCRIPTION
1. 안드로이드 에뮬레이터로 구동할 경우 localhost 서버가 에뮬레이터 내부 IP로 잡히기 때문에 설정을 달리 해야함.
그 IP가 10.0.2.2 라고 한다.

2. 웹으로 구동할경우 그대로 localhost에서 repository가 구동되어야 하는데 웹인지 아닌지 판단하는 방법이 2가지가 있다.
  - `kIsWeb` bool value로 확인
  - `Platform.IsAndroid` bool value로 확인 (이걸로 확인할경우 web 에서는 구현이 안되있기 때문에 Exception이 발생함)
두번째 방법도 `try/catch`를 이용하면 되지만, 간단하게 첫번째 방법으로 구현했음