### PR TITLE
Enable trainer enum type

### DIFF
--- a/fitqa_flutter/lib/src/domain/entities/common/enum/common_eunm.dart
+++ b/fitqa_flutter/lib/src/domain/entities/common/enum/common_eunm.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+enum WorkOutArea {
+  @JsonValue("LOWER")
+  lower,
+  @JsonValue("BACK")
+  back,
+  @JsonValue("CHEST")
+  chest,
+  @JsonValue("SHOULDER")
+  shoulder,
+  @JsonValue("ARM")
+  arm,
+}
+
+extension Converter on WorkOutArea {
+  String toStringType() {
+    switch (this) {
+      case WorkOutArea.lower:
+        return '하체';
+      case WorkOutArea.back:
+        return '등';
+      case WorkOutArea.chest:
+        return '가슴';
+      case WorkOutArea.shoulder:
+        return '어깨';
+      case WorkOutArea.arm:
+        return '팔';
+    }
+  }
+}

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.dart
@@ -14,7 +14,7 @@ abstract class Trainer with _$Trainer {
   const factory Trainer(
       {required String trainerToken,
       required String name,
-      required String style,
+      required WorkOutStyle style,
       required String introduceTitle,
       required String introduceContext,
       required int likesCount,
@@ -26,4 +26,26 @@ abstract class Trainer with _$Trainer {
 
   factory Trainer.fromJson(Map<String, dynamic> json) =>
       _$TrainerFromJson(json);
+}
+
+enum WorkOutStyle {
+  @JsonValue("NONE")
+  none,
+  @JsonValue("BODY_BUILDING")
+  bodyBuilding,
+  @JsonValue("DIET")
+  diet,
+}
+
+extension Converter on WorkOutStyle {
+  String toStringType() {
+    switch (this) {
+      case WorkOutStyle.none:
+        return '없음';
+      case WorkOutStyle.bodyBuilding:
+        return '보디빌딩';
+      case WorkOutStyle.diet:
+        return '다이어트';
+    }
+  }
 }

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.freezed.dart
@@ -25,7 +25,7 @@ class _$TrainerTearOff {
   _Trainer call(
       {required String trainerToken,
       required String name,
-      required String style,
+      required WorkOutStyle style,
       required String introduceTitle,
       required String introduceContext,
       required int likesCount,
@@ -61,7 +61,7 @@ const $Trainer = _$TrainerTearOff();
 mixin _$Trainer {
   String get trainerToken => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
-  String get style => throw _privateConstructorUsedError;
+  WorkOutStyle get style => throw _privateConstructorUsedError;
   String get introduceTitle => throw _privateConstructorUsedError;
   String get introduceContext => throw _privateConstructorUsedError;
   int get likesCount => throw _privateConstructorUsedError;
@@ -85,7 +85,7 @@ abstract class $TrainerCopyWith<$Res> {
   $Res call(
       {String trainerToken,
       String name,
-      String style,
+      WorkOutStyle style,
       String introduceTitle,
       String introduceContext,
       int likesCount,
@@ -130,7 +130,7 @@ class _$TrainerCopyWithImpl<$Res> implements $TrainerCopyWith<$Res> {
       style: style == freezed
           ? _value.style
           : style // ignore: cast_nullable_to_non_nullable
-              as String,
+              as WorkOutStyle,
       introduceTitle: introduceTitle == freezed
           ? _value.introduceTitle
           : introduceTitle // ignore: cast_nullable_to_non_nullable
@@ -175,7 +175,7 @@ abstract class _$TrainerCopyWith<$Res> implements $TrainerCopyWith<$Res> {
   $Res call(
       {String trainerToken,
       String name,
-      String style,
+      WorkOutStyle style,
       String introduceTitle,
       String introduceContext,
       int likesCount,
@@ -221,7 +221,7 @@ class __$TrainerCopyWithImpl<$Res> extends _$TrainerCopyWithImpl<$Res>
       style: style == freezed
           ? _value.style
           : style // ignore: cast_nullable_to_non_nullable
-              as String,
+              as WorkOutStyle,
       introduceTitle: introduceTitle == freezed
           ? _value.introduceTitle
           : introduceTitle // ignore: cast_nullable_to_non_nullable
@@ -282,7 +282,7 @@ class _$_Trainer implements _Trainer {
   @override
   final String name;
   @override
-  final String style;
+  final WorkOutStyle style;
   @override
   final String introduceTitle;
   @override
@@ -359,7 +359,7 @@ abstract class _Trainer implements Trainer {
   const factory _Trainer(
       {required String trainerToken,
       required String name,
-      required String style,
+      required WorkOutStyle style,
       required String introduceTitle,
       required String introduceContext,
       required int likesCount,
@@ -376,7 +376,7 @@ abstract class _Trainer implements Trainer {
   @override
   String get name;
   @override
-  String get style;
+  WorkOutStyle get style;
   @override
   String get introduceTitle;
   @override

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer/trainer.g.dart
@@ -9,7 +9,7 @@ part of 'trainer.dart';
 _$_Trainer _$$_TrainerFromJson(Map<String, dynamic> json) => _$_Trainer(
       trainerToken: json['trainerToken'] as String,
       name: json['name'] as String,
-      style: json['style'] as String,
+      style: $enumDecode(_$WorkOutStyleEnumMap, json['style']),
       introduceTitle: json['introduceTitle'] as String,
       introduceContext: json['introduceContext'] as String,
       likesCount: json['likesCount'] as int,
@@ -34,7 +34,7 @@ Map<String, dynamic> _$$_TrainerToJson(_$_Trainer instance) =>
     <String, dynamic>{
       'trainerToken': instance.trainerToken,
       'name': instance.name,
-      'style': instance.style,
+      'style': _$WorkOutStyleEnumMap[instance.style],
       'introduceTitle': instance.introduceTitle,
       'introduceContext': instance.introduceContext,
       'likesCount': instance.likesCount,
@@ -44,3 +44,9 @@ Map<String, dynamic> _$$_TrainerToJson(_$_Trainer instance) =>
       'interestAreas': instance.interestAreas,
       'sns': instance.sns,
     };
+
+const _$WorkOutStyleEnumMap = {
+  WorkOutStyle.none: 'NONE',
+  WorkOutStyle.bodyBuilding: 'BODY_BUILDING',
+  WorkOutStyle.diet: 'DIET',
+};

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.dart
@@ -7,10 +7,17 @@ part 'trainer_career.g.dart';
 @freezed
 abstract class TrainerCareer with _$TrainerCareer {
   const factory TrainerCareer({
-    required int contestId,
-    required String awards,
+    required String description,
+    required CareerType type,
   }) = _TrainerCareer;
 
   factory TrainerCareer.fromJson(Map<String, dynamic> json) =>
       _$TrainerCareerFromJson(json);
+}
+
+enum CareerType {
+  @JsonValue("CAREER")
+  career,
+  @JsonValue("LICENSE")
+  license,
 }

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.freezed.dart
@@ -22,10 +22,10 @@ TrainerCareer _$TrainerCareerFromJson(Map<String, dynamic> json) {
 class _$TrainerCareerTearOff {
   const _$TrainerCareerTearOff();
 
-  _TrainerCareer call({required int contestId, required String awards}) {
+  _TrainerCareer call({required String description, required CareerType type}) {
     return _TrainerCareer(
-      contestId: contestId,
-      awards: awards,
+      description: description,
+      type: type,
     );
   }
 
@@ -39,8 +39,8 @@ const $TrainerCareer = _$TrainerCareerTearOff();
 
 /// @nodoc
 mixin _$TrainerCareer {
-  int get contestId => throw _privateConstructorUsedError;
-  String get awards => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  CareerType get type => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -53,7 +53,7 @@ abstract class $TrainerCareerCopyWith<$Res> {
   factory $TrainerCareerCopyWith(
           TrainerCareer value, $Res Function(TrainerCareer) then) =
       _$TrainerCareerCopyWithImpl<$Res>;
-  $Res call({int contestId, String awards});
+  $Res call({String description, CareerType type});
 }
 
 /// @nodoc
@@ -67,18 +67,18 @@ class _$TrainerCareerCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? contestId = freezed,
-    Object? awards = freezed,
+    Object? description = freezed,
+    Object? type = freezed,
   }) {
     return _then(_value.copyWith(
-      contestId: contestId == freezed
-          ? _value.contestId
-          : contestId // ignore: cast_nullable_to_non_nullable
-              as int,
-      awards: awards == freezed
-          ? _value.awards
-          : awards // ignore: cast_nullable_to_non_nullable
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
               as String,
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as CareerType,
     ));
   }
 }
@@ -90,7 +90,7 @@ abstract class _$TrainerCareerCopyWith<$Res>
           _TrainerCareer value, $Res Function(_TrainerCareer) then) =
       __$TrainerCareerCopyWithImpl<$Res>;
   @override
-  $Res call({int contestId, String awards});
+  $Res call({String description, CareerType type});
 }
 
 /// @nodoc
@@ -106,18 +106,18 @@ class __$TrainerCareerCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? contestId = freezed,
-    Object? awards = freezed,
+    Object? description = freezed,
+    Object? type = freezed,
   }) {
     return _then(_TrainerCareer(
-      contestId: contestId == freezed
-          ? _value.contestId
-          : contestId // ignore: cast_nullable_to_non_nullable
-              as int,
-      awards: awards == freezed
-          ? _value.awards
-          : awards // ignore: cast_nullable_to_non_nullable
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
               as String,
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as CareerType,
     ));
   }
 }
@@ -125,19 +125,19 @@ class __$TrainerCareerCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_TrainerCareer implements _TrainerCareer {
-  const _$_TrainerCareer({required this.contestId, required this.awards});
+  const _$_TrainerCareer({required this.description, required this.type});
 
   factory _$_TrainerCareer.fromJson(Map<String, dynamic> json) =>
       _$$_TrainerCareerFromJson(json);
 
   @override
-  final int contestId;
+  final String description;
   @override
-  final String awards;
+  final CareerType type;
 
   @override
   String toString() {
-    return 'TrainerCareer(contestId: $contestId, awards: $awards)';
+    return 'TrainerCareer(description: $description, type: $type)';
   }
 
   @override
@@ -145,15 +145,16 @@ class _$_TrainerCareer implements _TrainerCareer {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _TrainerCareer &&
-            const DeepCollectionEquality().equals(other.contestId, contestId) &&
-            const DeepCollectionEquality().equals(other.awards, awards));
+            const DeepCollectionEquality()
+                .equals(other.description, description) &&
+            const DeepCollectionEquality().equals(other.type, type));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(contestId),
-      const DeepCollectionEquality().hash(awards));
+      const DeepCollectionEquality().hash(description),
+      const DeepCollectionEquality().hash(type));
 
   @JsonKey(ignore: true)
   @override
@@ -168,15 +169,16 @@ class _$_TrainerCareer implements _TrainerCareer {
 
 abstract class _TrainerCareer implements TrainerCareer {
   const factory _TrainerCareer(
-      {required int contestId, required String awards}) = _$_TrainerCareer;
+      {required String description,
+      required CareerType type}) = _$_TrainerCareer;
 
   factory _TrainerCareer.fromJson(Map<String, dynamic> json) =
       _$_TrainerCareer.fromJson;
 
   @override
-  int get contestId;
+  String get description;
   @override
-  String get awards;
+  CareerType get type;
   @override
   @JsonKey(ignore: true)
   _$TrainerCareerCopyWith<_TrainerCareer> get copyWith =>

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_career/trainer_career.g.dart
@@ -8,12 +8,17 @@ part of 'trainer_career.dart';
 
 _$_TrainerCareer _$$_TrainerCareerFromJson(Map<String, dynamic> json) =>
     _$_TrainerCareer(
-      contestId: json['contestId'] as int,
-      awards: json['awards'] as String,
+      description: json['description'] as String,
+      type: $enumDecode(_$CareerTypeEnumMap, json['type']),
     );
 
 Map<String, dynamic> _$$_TrainerCareerToJson(_$_TrainerCareer instance) =>
     <String, dynamic>{
-      'contestId': instance.contestId,
-      'awards': instance.awards,
+      'description': instance.description,
+      'type': _$CareerTypeEnumMap[instance.type],
     };
+
+const _$CareerTypeEnumMap = {
+  CareerType.career: 'CAREER',
+  CareerType.license: 'LICENSE',
+};

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.dart
@@ -1,3 +1,4 @@
+import 'package:fitqa/src/domain/entities/common/enum/common_eunm.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'trainer_feedback_price.freezed.dart';
@@ -7,7 +8,7 @@ part 'trainer_feedback_price.g.dart';
 @freezed
 abstract class TrainerFeedbackPrice with _$TrainerFeedbackPrice {
   const factory TrainerFeedbackPrice({
-    required String interestArea,
+    required WorkOutArea area,
     required int price,
   }) = _TrainerFeedbackPrice;
 

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.freezed.dart
@@ -22,10 +22,9 @@ TrainerFeedbackPrice _$TrainerFeedbackPriceFromJson(Map<String, dynamic> json) {
 class _$TrainerFeedbackPriceTearOff {
   const _$TrainerFeedbackPriceTearOff();
 
-  _TrainerFeedbackPrice call(
-      {required String interestArea, required int price}) {
+  _TrainerFeedbackPrice call({required WorkOutArea area, required int price}) {
     return _TrainerFeedbackPrice(
-      interestArea: interestArea,
+      area: area,
       price: price,
     );
   }
@@ -40,7 +39,7 @@ const $TrainerFeedbackPrice = _$TrainerFeedbackPriceTearOff();
 
 /// @nodoc
 mixin _$TrainerFeedbackPrice {
-  String get interestArea => throw _privateConstructorUsedError;
+  WorkOutArea get area => throw _privateConstructorUsedError;
   int get price => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -54,7 +53,7 @@ abstract class $TrainerFeedbackPriceCopyWith<$Res> {
   factory $TrainerFeedbackPriceCopyWith(TrainerFeedbackPrice value,
           $Res Function(TrainerFeedbackPrice) then) =
       _$TrainerFeedbackPriceCopyWithImpl<$Res>;
-  $Res call({String interestArea, int price});
+  $Res call({WorkOutArea area, int price});
 }
 
 /// @nodoc
@@ -68,14 +67,14 @@ class _$TrainerFeedbackPriceCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? interestArea = freezed,
+    Object? area = freezed,
     Object? price = freezed,
   }) {
     return _then(_value.copyWith(
-      interestArea: interestArea == freezed
-          ? _value.interestArea
-          : interestArea // ignore: cast_nullable_to_non_nullable
-              as String,
+      area: area == freezed
+          ? _value.area
+          : area // ignore: cast_nullable_to_non_nullable
+              as WorkOutArea,
       price: price == freezed
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
@@ -91,7 +90,7 @@ abstract class _$TrainerFeedbackPriceCopyWith<$Res>
           $Res Function(_TrainerFeedbackPrice) then) =
       __$TrainerFeedbackPriceCopyWithImpl<$Res>;
   @override
-  $Res call({String interestArea, int price});
+  $Res call({WorkOutArea area, int price});
 }
 
 /// @nodoc
@@ -107,14 +106,14 @@ class __$TrainerFeedbackPriceCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? interestArea = freezed,
+    Object? area = freezed,
     Object? price = freezed,
   }) {
     return _then(_TrainerFeedbackPrice(
-      interestArea: interestArea == freezed
-          ? _value.interestArea
-          : interestArea // ignore: cast_nullable_to_non_nullable
-              as String,
+      area: area == freezed
+          ? _value.area
+          : area // ignore: cast_nullable_to_non_nullable
+              as WorkOutArea,
       price: price == freezed
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
@@ -126,20 +125,19 @@ class __$TrainerFeedbackPriceCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_TrainerFeedbackPrice implements _TrainerFeedbackPrice {
-  const _$_TrainerFeedbackPrice(
-      {required this.interestArea, required this.price});
+  const _$_TrainerFeedbackPrice({required this.area, required this.price});
 
   factory _$_TrainerFeedbackPrice.fromJson(Map<String, dynamic> json) =>
       _$$_TrainerFeedbackPriceFromJson(json);
 
   @override
-  final String interestArea;
+  final WorkOutArea area;
   @override
   final int price;
 
   @override
   String toString() {
-    return 'TrainerFeedbackPrice(interestArea: $interestArea, price: $price)';
+    return 'TrainerFeedbackPrice(area: $area, price: $price)';
   }
 
   @override
@@ -147,15 +145,14 @@ class _$_TrainerFeedbackPrice implements _TrainerFeedbackPrice {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _TrainerFeedbackPrice &&
-            const DeepCollectionEquality()
-                .equals(other.interestArea, interestArea) &&
+            const DeepCollectionEquality().equals(other.area, area) &&
             const DeepCollectionEquality().equals(other.price, price));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(interestArea),
+      const DeepCollectionEquality().hash(area),
       const DeepCollectionEquality().hash(price));
 
   @JsonKey(ignore: true)
@@ -172,14 +169,14 @@ class _$_TrainerFeedbackPrice implements _TrainerFeedbackPrice {
 
 abstract class _TrainerFeedbackPrice implements TrainerFeedbackPrice {
   const factory _TrainerFeedbackPrice(
-      {required String interestArea,
+      {required WorkOutArea area,
       required int price}) = _$_TrainerFeedbackPrice;
 
   factory _TrainerFeedbackPrice.fromJson(Map<String, dynamic> json) =
       _$_TrainerFeedbackPrice.fromJson;
 
   @override
-  String get interestArea;
+  WorkOutArea get area;
   @override
   int get price;
   @override

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_feedback_price/trainer_feedback_price.g.dart
@@ -9,13 +9,21 @@ part of 'trainer_feedback_price.dart';
 _$_TrainerFeedbackPrice _$$_TrainerFeedbackPriceFromJson(
         Map<String, dynamic> json) =>
     _$_TrainerFeedbackPrice(
-      interestArea: json['interestArea'] as String,
+      area: $enumDecode(_$WorkOutAreaEnumMap, json['area']),
       price: json['price'] as int,
     );
 
 Map<String, dynamic> _$$_TrainerFeedbackPriceToJson(
         _$_TrainerFeedbackPrice instance) =>
     <String, dynamic>{
-      'interestArea': instance.interestArea,
+      'area': _$WorkOutAreaEnumMap[instance.area],
       'price': instance.price,
     };
+
+const _$WorkOutAreaEnumMap = {
+  WorkOutArea.lower: 'LOWER',
+  WorkOutArea.back: 'BACK',
+  WorkOutArea.chest: 'CHEST',
+  WorkOutArea.shoulder: 'SHOULDER',
+  WorkOutArea.arm: 'ARM',
+};

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.dart
@@ -8,9 +8,31 @@ part 'trainer_image.g.dart';
 abstract class TrainerImage with _$TrainerImage {
   const factory TrainerImage({
     required String imageUrl,
-    required String imageType,
+    required ImageType imageType,
   }) = _TrainerImage;
 
   factory TrainerImage.fromJson(Map<String, dynamic> json) =>
       _$TrainerImageFromJson(json);
+}
+
+enum ImageType {
+  @JsonValue("BACKGROUND")
+  background,
+  @JsonValue("GALLERY")
+  gallery,
+  @JsonValue("PROFILE")
+  profile,
+}
+
+extension Converter on ImageType {
+  String toStringType() {
+    switch (this) {
+      case ImageType.background:
+        return '배경';
+      case ImageType.gallery:
+        return '갤러리';
+      case ImageType.profile:
+        return '프로필';
+    }
+  }
 }

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.freezed.dart
@@ -22,7 +22,7 @@ TrainerImage _$TrainerImageFromJson(Map<String, dynamic> json) {
 class _$TrainerImageTearOff {
   const _$TrainerImageTearOff();
 
-  _TrainerImage call({required String imageUrl, required String imageType}) {
+  _TrainerImage call({required String imageUrl, required ImageType imageType}) {
     return _TrainerImage(
       imageUrl: imageUrl,
       imageType: imageType,
@@ -40,7 +40,7 @@ const $TrainerImage = _$TrainerImageTearOff();
 /// @nodoc
 mixin _$TrainerImage {
   String get imageUrl => throw _privateConstructorUsedError;
-  String get imageType => throw _privateConstructorUsedError;
+  ImageType get imageType => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -53,7 +53,7 @@ abstract class $TrainerImageCopyWith<$Res> {
   factory $TrainerImageCopyWith(
           TrainerImage value, $Res Function(TrainerImage) then) =
       _$TrainerImageCopyWithImpl<$Res>;
-  $Res call({String imageUrl, String imageType});
+  $Res call({String imageUrl, ImageType imageType});
 }
 
 /// @nodoc
@@ -77,7 +77,7 @@ class _$TrainerImageCopyWithImpl<$Res> implements $TrainerImageCopyWith<$Res> {
       imageType: imageType == freezed
           ? _value.imageType
           : imageType // ignore: cast_nullable_to_non_nullable
-              as String,
+              as ImageType,
     ));
   }
 }
@@ -89,7 +89,7 @@ abstract class _$TrainerImageCopyWith<$Res>
           _TrainerImage value, $Res Function(_TrainerImage) then) =
       __$TrainerImageCopyWithImpl<$Res>;
   @override
-  $Res call({String imageUrl, String imageType});
+  $Res call({String imageUrl, ImageType imageType});
 }
 
 /// @nodoc
@@ -115,7 +115,7 @@ class __$TrainerImageCopyWithImpl<$Res> extends _$TrainerImageCopyWithImpl<$Res>
       imageType: imageType == freezed
           ? _value.imageType
           : imageType // ignore: cast_nullable_to_non_nullable
-              as String,
+              as ImageType,
     ));
   }
 }
@@ -131,7 +131,7 @@ class _$_TrainerImage implements _TrainerImage {
   @override
   final String imageUrl;
   @override
-  final String imageType;
+  final ImageType imageType;
 
   @override
   String toString() {
@@ -166,7 +166,8 @@ class _$_TrainerImage implements _TrainerImage {
 
 abstract class _TrainerImage implements TrainerImage {
   const factory _TrainerImage(
-      {required String imageUrl, required String imageType}) = _$_TrainerImage;
+      {required String imageUrl,
+      required ImageType imageType}) = _$_TrainerImage;
 
   factory _TrainerImage.fromJson(Map<String, dynamic> json) =
       _$_TrainerImage.fromJson;
@@ -174,7 +175,7 @@ abstract class _TrainerImage implements TrainerImage {
   @override
   String get imageUrl;
   @override
-  String get imageType;
+  ImageType get imageType;
   @override
   @JsonKey(ignore: true)
   _$TrainerImageCopyWith<_TrainerImage> get copyWith =>

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_image/trainer_image.g.dart
@@ -9,11 +9,17 @@ part of 'trainer_image.dart';
 _$_TrainerImage _$$_TrainerImageFromJson(Map<String, dynamic> json) =>
     _$_TrainerImage(
       imageUrl: json['imageUrl'] as String,
-      imageType: json['imageType'] as String,
+      imageType: $enumDecode(_$ImageTypeEnumMap, json['imageType']),
     );
 
 Map<String, dynamic> _$$_TrainerImageToJson(_$_TrainerImage instance) =>
     <String, dynamic>{
       'imageUrl': instance.imageUrl,
-      'imageType': instance.imageType,
+      'imageType': _$ImageTypeEnumMap[instance.imageType],
     };
+
+const _$ImageTypeEnumMap = {
+  ImageType.background: 'BACKGROUND',
+  ImageType.gallery: 'GALLERY',
+  ImageType.profile: 'PROFILE',
+};

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.dart
@@ -1,3 +1,4 @@
+import 'package:fitqa/src/domain/entities/common/enum/common_eunm.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'trainer_interest.freezed.dart';
@@ -6,7 +7,7 @@ part 'trainer_interest.g.dart';
 
 @freezed
 abstract class TrainerInterestArea with _$TrainerInterestArea {
-  const factory TrainerInterestArea({required String interestArea}) =
+  const factory TrainerInterestArea({required WorkOutArea interestArea}) =
       _TrainerInterest;
 
   factory TrainerInterestArea.fromJson(Map<String, dynamic> json) =>

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.freezed.dart
@@ -22,7 +22,7 @@ TrainerInterestArea _$TrainerInterestAreaFromJson(Map<String, dynamic> json) {
 class _$TrainerInterestAreaTearOff {
   const _$TrainerInterestAreaTearOff();
 
-  _TrainerInterest call({required String interestArea}) {
+  _TrainerInterest call({required WorkOutArea interestArea}) {
     return _TrainerInterest(
       interestArea: interestArea,
     );
@@ -38,7 +38,7 @@ const $TrainerInterestArea = _$TrainerInterestAreaTearOff();
 
 /// @nodoc
 mixin _$TrainerInterestArea {
-  String get interestArea => throw _privateConstructorUsedError;
+  WorkOutArea get interestArea => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -51,7 +51,7 @@ abstract class $TrainerInterestAreaCopyWith<$Res> {
   factory $TrainerInterestAreaCopyWith(
           TrainerInterestArea value, $Res Function(TrainerInterestArea) then) =
       _$TrainerInterestAreaCopyWithImpl<$Res>;
-  $Res call({String interestArea});
+  $Res call({WorkOutArea interestArea});
 }
 
 /// @nodoc
@@ -71,7 +71,7 @@ class _$TrainerInterestAreaCopyWithImpl<$Res>
       interestArea: interestArea == freezed
           ? _value.interestArea
           : interestArea // ignore: cast_nullable_to_non_nullable
-              as String,
+              as WorkOutArea,
     ));
   }
 }
@@ -83,7 +83,7 @@ abstract class _$TrainerInterestCopyWith<$Res>
           _TrainerInterest value, $Res Function(_TrainerInterest) then) =
       __$TrainerInterestCopyWithImpl<$Res>;
   @override
-  $Res call({String interestArea});
+  $Res call({WorkOutArea interestArea});
 }
 
 /// @nodoc
@@ -105,7 +105,7 @@ class __$TrainerInterestCopyWithImpl<$Res>
       interestArea: interestArea == freezed
           ? _value.interestArea
           : interestArea // ignore: cast_nullable_to_non_nullable
-              as String,
+              as WorkOutArea,
     ));
   }
 }
@@ -119,7 +119,7 @@ class _$_TrainerInterest implements _TrainerInterest {
       _$$_TrainerInterestFromJson(json);
 
   @override
-  final String interestArea;
+  final WorkOutArea interestArea;
 
   @override
   String toString() {
@@ -151,14 +151,14 @@ class _$_TrainerInterest implements _TrainerInterest {
 }
 
 abstract class _TrainerInterest implements TrainerInterestArea {
-  const factory _TrainerInterest({required String interestArea}) =
+  const factory _TrainerInterest({required WorkOutArea interestArea}) =
       _$_TrainerInterest;
 
   factory _TrainerInterest.fromJson(Map<String, dynamic> json) =
       _$_TrainerInterest.fromJson;
 
   @override
-  String get interestArea;
+  WorkOutArea get interestArea;
   @override
   @JsonKey(ignore: true)
   _$TrainerInterestCopyWith<_TrainerInterest> get copyWith =>

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_interest/trainer_interest.g.dart
@@ -8,10 +8,18 @@ part of 'trainer_interest.dart';
 
 _$_TrainerInterest _$$_TrainerInterestFromJson(Map<String, dynamic> json) =>
     _$_TrainerInterest(
-      interestArea: json['interestArea'] as String,
+      interestArea: $enumDecode(_$WorkOutAreaEnumMap, json['interestArea']),
     );
 
 Map<String, dynamic> _$$_TrainerInterestToJson(_$_TrainerInterest instance) =>
     <String, dynamic>{
-      'interestArea': instance.interestArea,
+      'interestArea': _$WorkOutAreaEnumMap[instance.interestArea],
     };
+
+const _$WorkOutAreaEnumMap = {
+  WorkOutArea.lower: 'LOWER',
+  WorkOutArea.back: 'BACK',
+  WorkOutArea.chest: 'CHEST',
+  WorkOutArea.shoulder: 'SHOULDER',
+  WorkOutArea.arm: 'ARM',
+};

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.dart
@@ -6,9 +6,31 @@ part 'trainer_sns.g.dart';
 
 @freezed
 abstract class TrainerSns with _$TrainerSns {
-  const factory TrainerSns({required String snsType, required String snsUrl}) =
+  const factory TrainerSns({required SnsType snsType, required String snsUrl}) =
       _TrainerSns;
 
   factory TrainerSns.fromJson(Map<String, dynamic> json) =>
       _$TrainerSnsFromJson(json);
+}
+
+enum SnsType {
+  @JsonValue("FACEBOOK")
+  facebook,
+  @JsonValue("INSTAGRAM")
+  instagram,
+  @JsonValue("YOUTUBE")
+  youtube,
+}
+
+extension Converter on SnsType {
+  String toStringType() {
+    switch (this) {
+      case SnsType.facebook:
+        return '페이스북';
+      case SnsType.instagram:
+        return '인스타그램';
+      case SnsType.youtube:
+        return '유튜브';
+    }
+  }
 }

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.freezed.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.freezed.dart
@@ -22,7 +22,7 @@ TrainerSns _$TrainerSnsFromJson(Map<String, dynamic> json) {
 class _$TrainerSnsTearOff {
   const _$TrainerSnsTearOff();
 
-  _TrainerSns call({required String snsType, required String snsUrl}) {
+  _TrainerSns call({required SnsType snsType, required String snsUrl}) {
     return _TrainerSns(
       snsType: snsType,
       snsUrl: snsUrl,
@@ -39,7 +39,7 @@ const $TrainerSns = _$TrainerSnsTearOff();
 
 /// @nodoc
 mixin _$TrainerSns {
-  String get snsType => throw _privateConstructorUsedError;
+  SnsType get snsType => throw _privateConstructorUsedError;
   String get snsUrl => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -53,7 +53,7 @@ abstract class $TrainerSnsCopyWith<$Res> {
   factory $TrainerSnsCopyWith(
           TrainerSns value, $Res Function(TrainerSns) then) =
       _$TrainerSnsCopyWithImpl<$Res>;
-  $Res call({String snsType, String snsUrl});
+  $Res call({SnsType snsType, String snsUrl});
 }
 
 /// @nodoc
@@ -73,7 +73,7 @@ class _$TrainerSnsCopyWithImpl<$Res> implements $TrainerSnsCopyWith<$Res> {
       snsType: snsType == freezed
           ? _value.snsType
           : snsType // ignore: cast_nullable_to_non_nullable
-              as String,
+              as SnsType,
       snsUrl: snsUrl == freezed
           ? _value.snsUrl
           : snsUrl // ignore: cast_nullable_to_non_nullable
@@ -88,7 +88,7 @@ abstract class _$TrainerSnsCopyWith<$Res> implements $TrainerSnsCopyWith<$Res> {
           _TrainerSns value, $Res Function(_TrainerSns) then) =
       __$TrainerSnsCopyWithImpl<$Res>;
   @override
-  $Res call({String snsType, String snsUrl});
+  $Res call({SnsType snsType, String snsUrl});
 }
 
 /// @nodoc
@@ -110,7 +110,7 @@ class __$TrainerSnsCopyWithImpl<$Res> extends _$TrainerSnsCopyWithImpl<$Res>
       snsType: snsType == freezed
           ? _value.snsType
           : snsType // ignore: cast_nullable_to_non_nullable
-              as String,
+              as SnsType,
       snsUrl: snsUrl == freezed
           ? _value.snsUrl
           : snsUrl // ignore: cast_nullable_to_non_nullable
@@ -128,7 +128,7 @@ class _$_TrainerSns implements _TrainerSns {
       _$$_TrainerSnsFromJson(json);
 
   @override
-  final String snsType;
+  final SnsType snsType;
   @override
   final String snsUrl;
 
@@ -164,14 +164,14 @@ class _$_TrainerSns implements _TrainerSns {
 }
 
 abstract class _TrainerSns implements TrainerSns {
-  const factory _TrainerSns({required String snsType, required String snsUrl}) =
-      _$_TrainerSns;
+  const factory _TrainerSns(
+      {required SnsType snsType, required String snsUrl}) = _$_TrainerSns;
 
   factory _TrainerSns.fromJson(Map<String, dynamic> json) =
       _$_TrainerSns.fromJson;
 
   @override
-  String get snsType;
+  SnsType get snsType;
   @override
   String get snsUrl;
   @override

--- a/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.g.dart
+++ b/fitqa_flutter/lib/src/domain/entities/trainer/trainer_sns/trainer_sns.g.dart
@@ -8,12 +8,18 @@ part of 'trainer_sns.dart';
 
 _$_TrainerSns _$$_TrainerSnsFromJson(Map<String, dynamic> json) =>
     _$_TrainerSns(
-      snsType: json['snsType'] as String,
+      snsType: $enumDecode(_$SnsTypeEnumMap, json['snsType']),
       snsUrl: json['snsUrl'] as String,
     );
 
 Map<String, dynamic> _$$_TrainerSnsToJson(_$_TrainerSns instance) =>
     <String, dynamic>{
-      'snsType': instance.snsType,
+      'snsType': _$SnsTypeEnumMap[instance.snsType],
       'snsUrl': instance.snsUrl,
     };
+
+const _$SnsTypeEnumMap = {
+  SnsType.facebook: 'FACEBOOK',
+  SnsType.instagram: 'INSTAGRAM',
+  SnsType.youtube: 'YOUTUBE',
+};

--- a/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
+++ b/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
@@ -1,5 +1,6 @@
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:fitqa/src/domain/entities/trainer/trainer_image/trainer_image.dart';
 import 'package:fitqa/src/presentation/widgets/trainer/detail/trainer_career_list.dart';
 import 'package:fitqa/src/presentation/widgets/trainer/detail/trainer_career_summary.dart';
 import 'package:fitqa/src/presentation/widgets/trainer/detail/trainer_detail_info.dart';
@@ -69,7 +70,7 @@ class _ScreenTrainerDetailState extends ConsumerState<ScreenTrainerDetail>
 
   Widget buildFlexibleSpace() {
     String backgroundImageUrl = widget.trainer.images
-        .firstWhere((element) => element.imageType == "BACKGROUND")
+        .firstWhere((element) => element.imageType == ImageType.background)
         .imageUrl;
     return FlexibleSpaceBar(
         collapseMode: CollapseMode.pin,

--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_detail_info.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_detail_info.dart
@@ -1,4 +1,6 @@
+import 'package:fitqa/src/domain/entities/common/enum/common_eunm.dart';
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:fitqa/src/domain/entities/trainer/trainer_image/trainer_image.dart';
 import 'package:fitqa/src/presentation/widgets/common/area_small_widget.dart';
 import 'package:fitqa/src/theme/color.dart';
 import 'package:fitqa/src/theme/dimen.dart';
@@ -11,10 +13,8 @@ class TrainerDetailInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // FIXME(in.heo)
-    // - makes imageType from String to enum class
     final String profileImage = trainer.images
-        .firstWhere((element) => element.imageType == "PROFILE")
+        .firstWhere((element) => element.imageType == ImageType.profile)
         .imageUrl;
 
     return Column(
@@ -35,7 +35,7 @@ class TrainerDetailInfo extends StatelessWidget {
                 fontSize: 30,
                 fontWeight: FontWeight.bold)),
         const SizedBox(height: 16),
-        Text(trainer.style,
+        Text(trainer.style.toStringType(),
             style: const TextStyle(color: FColors.white, fontSize: 14)),
         const SizedBox(height: 14),
         Row(children: _buildInterestAreas())
@@ -48,7 +48,7 @@ class TrainerDetailInfo extends StatelessWidget {
 
     for (var element in trainer.interestAreas) {
       widgets.add(AreaSmallWidget(
-        element.interestArea,
+        element.interestArea.toStringType(),
         textColor: FColors.white,
         backgroundColor: FColors.transparent,
         borderColor: FColors.white,

--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_introduce.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_introduce.dart
@@ -1,4 +1,5 @@
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:fitqa/src/domain/entities/trainer/trainer_image/trainer_image.dart';
 import 'package:fitqa/src/theme/dimen.dart';
 import 'package:flutter/material.dart';
 
@@ -9,10 +10,8 @@ class TrainerIntroduce extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //FIXME(in.heo)
-    // - makes imageType from String to enum
     final profileImage = trainer.images
-        .firstWhere((element) => element.imageType == "PROFILE")
+        .firstWhere((element) => element.imageType == ImageType.profile)
         .imageUrl;
 
     return Container(

--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_sns.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_sns.dart
@@ -1,5 +1,6 @@
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:fitqa/src/domain/entities/trainer/trainer_sns/trainer_sns.dart';
 import 'package:fitqa/src/presentation/widgets/trainer/detail/trainer_sns_item.dart';
 import 'package:fitqa/src/theme/color.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +12,7 @@ class TrainerSns extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Map<String, String> snsMap = {};
+    Map<SnsType, String> snsMap = {};
 
     for (var element in trainer.sns) {
       snsMap[element.snsType] = element.snsUrl;
@@ -38,13 +39,13 @@ class TrainerSns extends StatelessWidget {
   List<Widget> _buildSnsList(Map snsMap) {
     List<Widget> snsList = [];
     snsList.add(TrainerSnsItem(
-        const Icon(FitQaIcon.facebook), snsMap['FACEBOOK'] ?? ""));
+        const Icon(FitQaIcon.facebook), snsMap[SnsType.facebook] ?? ""));
     snsList.add(const SizedBox(height: 14));
     snsList.add(TrainerSnsItem(
-        const Icon(FitQaIcon.instagram), snsMap['INSTAGRAM'] ?? ""));
+        const Icon(FitQaIcon.instagram), snsMap[SnsType.instagram] ?? ""));
     snsList.add(const SizedBox(height: 14));
     snsList.add(TrainerSnsItem(
-        const Icon(FitQaIcon.facebook), snsMap['YOUTUBE'] ?? ""));
+        const Icon(FitQaIcon.facebook), snsMap[SnsType.youtube] ?? ""));
     snsList.add(const SizedBox(height: 31));
 
     return snsList;

--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/list/trainer_card_view.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/list/trainer_card_view.dart
@@ -1,4 +1,6 @@
+import 'package:fitqa/src/domain/entities/common/enum/common_eunm.dart';
 import 'package:fitqa/src/domain/entities/trainer/trainer/trainer.dart';
+import 'package:fitqa/src/domain/entities/trainer/trainer_image/trainer_image.dart';
 import 'package:fitqa/src/presentation/screens/screen_trainer_detail.dart';
 import 'package:fitqa/src/presentation/widgets/common/area_small_widget.dart';
 import 'package:fitqa/src/presentation/widgets/trainer/list/trainer_card_image.dart';
@@ -47,8 +49,9 @@ class TrainerCardView extends ConsumerWidget {
 
     //TODO(in.heo)
     // - Ordering을 추가해야 할 수도, 어플에서 보여지는 위젯의 순서
-    final galleryImages =
-        data.images.where((element) => element.imageType == "GALLERY").toList();
+    final galleryImages = data.images
+        .where((element) => element.imageType == ImageType.gallery)
+        .toList();
 
     for (var i = 0; i < FDimen.trainerCardImageCount; i++) {
       if (galleryImages.length > i) {
@@ -111,7 +114,7 @@ class TrainerCardView extends ConsumerWidget {
     if (data.interestAreas.isEmpty) return interestAreas;
 
     for (var area in data.interestAreas) {
-      interestAreas.add(AreaSmallWidget(area.interestArea,
+      interestAreas.add(AreaSmallWidget(area.interestArea.toStringType(),
           textColor: FColors.black,
           backgroundColor: FColors.white,
           borderColor: FColors.black));


### PR DESCRIPTION
### 변경 내용
- [x] Spring에서 변경된 데이터 타입을 반영함 ( `TrainerCareer` 타입, 데이터 네이밍 `(interestArea -> area)` 
- [x] String으로 처리하던 타입들을 enum으로 변경함
```dart
const factory Trainer(
      {required String trainerToken,
      required String name,
      required String style,
      required WorkOutStyle style,
      required String introduceTitle,
      required String introduceContext,
      required int likesCount,
  factory Trainer.fromJson(Map<String, dynamic> json) =>
      _$TrainerFromJson(json);
}

enum WorkOutStyle {
  @JsonValue("NONE")
  none,
  @JsonValue("BODY_BUILDING")
  bodyBuilding,
  @JsonValue("DIET")
  diet,
}

extension Converter on WorkOutStyle {
  String toStringType() {
    switch (this) {
      case WorkOutStyle.none:
        return '없음';
      case WorkOutStyle.bodyBuilding:
        return '보디빌딩';
      case WorkOutStyle.diet:
        return '다이어트';
    }
  }
}
```

| Image1  | Image2 |
|:-------:|:------:|
|![image](https://user-images.githubusercontent.com/50590025/163662700-077fb303-e209-499d-beee-04e48e1829d1.png)|![image](https://user-images.githubusercontent.com/50590025/163662707-7fc007f2-4321-41d1-af06-2e316566ab14.png)|
