### PR TITLE
Hotfix: Fix answer complete tag on feedback detail

### DIFF
--- a/fitqa_flutter/lib/src/presentation/widgets/feedback/detail/section_user_profile.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/feedback/detail/section_user_profile.dart
@@ -1,5 +1,6 @@
 import 'package:fitqa/src/application/feedback/feedback_detail.dart';
 import 'package:fitqa/src/common/time_utils.dart';
+import 'package:fitqa/src/domain/entities/feedback/fitqa_feedback/fitqa_feedback.dart';
 import 'package:fitqa/src/presentation/widgets/common/small_info_box.dart';
 import 'package:fitqa/src/theme/color.dart';
 import 'package:flutter/material.dart';
@@ -45,7 +46,10 @@ class SectionUserProfile extends ConsumerWidget {
               ],
             ),
           ),
-          SmallInfoBox(text: "답변대기")
+          SmallInfoBox(
+            text: feedbackDetail.status.toStringType(),
+            outlined: feedbackDetail.status == FeedbackStatus.prepare,
+          )
         ],
       ),
     );


### PR DESCRIPTION
### 기존 문제상황
- 답변완료인 피드백도 답변완료 태그가 제대로 안나왔음.
- 피드백 목록에서는 제대로 나오고 있음

### 변경 내용
- 피드백 목록에서 나오는것처럼 수정함

### 결론
![1](https://user-images.githubusercontent.com/13013735/163936748-c553785f-f94d-47a6-9338-53896171e8b8.png)

