### PR TITLE
update widget with ownerTrainerToken

### DIFF
--- a/fitqa_flutter/lib/src/presentation/home.dart
+++ b/fitqa_flutter/lib/src/presentation/home.dart
@@ -1,3 +1,4 @@
+import 'package:fitqa/src/application/storage/user_token_facade.dart';
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/presentation/screens/screen_feedback_request.dart';
 import 'package:fitqa/src/presentation/screens/screen_home.dart';
@@ -16,6 +17,7 @@ class Home extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final PageModel navigation = ref.watch(navigationProvider);
+    final ownerUserToken = ref.watch(userTokenProvider);
 
     return Scaffold(
         body: currentScreen(navigation.index),
@@ -35,7 +37,9 @@ class Home extends ConsumerWidget {
             ref.read(navigationProvider.notifier).movePage(index);
           },
         ),
-        floatingActionButton: currentFAB(context, navigation.index));
+        floatingActionButton: ownerUserToken.isNotEmpty
+            ? currentFAB(context, navigation.index)
+            : null);
   }
 
   Widget currentScreen(int index) {

--- a/fitqa_flutter/lib/src/presentation/screens/screen_mypage.dart
+++ b/fitqa_flutter/lib/src/presentation/screens/screen_mypage.dart
@@ -1,14 +1,40 @@
+import 'package:fitqa/src/application/storage/trainer_token_facade.dart';
+import 'package:fitqa/src/application/storage/user_token_facade.dart';
+import 'package:fitqa/src/application/trainer/trainer_detail.dart';
+import 'package:fitqa/src/presentation/screens/screen_trainer_detail.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ScreenMyPage extends StatelessWidget {
+class ScreenMyPage extends ConsumerWidget {
   const ScreenMyPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      child: Center(
-        child: Text('MyPage Screen'),
-      ),
-    );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ownerTrainerToken = ref.watch(trainerTokenProvider);
+    final ownerUserToken = ref.watch(userTokenProvider);
+    final trainerDetailTokenController =
+        ref.watch(selectedTrainerTokenProvider.notifier);
+
+    if (ownerUserToken.isEmpty && ownerTrainerToken.isEmpty) {
+      return _buildLoginPage();
+    } else if (ownerUserToken.isNotEmpty) {
+      return _buildUserMyPage();
+    } else {
+      return _buildTrainerMyPage(
+          trainerDetailTokenController, ownerTrainerToken);
+    }
   }
+
+  Widget _buildUserMyPage() => const Center(
+        child: Text('User MyPage Screen'),
+      );
+
+  Widget _buildTrainerMyPage(
+      selectedTrainerTokenController, String trainerToken) {
+    selectedTrainerTokenController.state = trainerToken;
+
+    return const ScreenTrainerDetail();
+  }
+
+  Widget _buildLoginPage() => const Center(child: Text('Login Screen'));
 }

--- a/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
+++ b/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
@@ -1,3 +1,4 @@
+import 'package:fitqa/src/application/storage/trainer_token_facade.dart';
 import 'package:fitqa/src/application/trainer/trainer_detail.dart';
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/presentation/screens/screen_edit_trainer_detail.dart';
@@ -19,13 +20,13 @@ class ScreenTrainerDetail extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final trainerDetail = ref.watch(trainerDetailProvider);
-
+    final ownerTrainerToken = ref.watch(trainerTokenProvider);
     return Scaffold(
       body: CustomScrollView(
         slivers: trainerDetail.maybeWhen(
             orElse: () => [_buildLoading()],
             success: (_) => [
-                  buildAppBar(context),
+                  buildAppBar(context, ownerTrainerToken),
                   buildContext(),
                   buildFeedbackListView()
                 ]),
@@ -33,7 +34,7 @@ class ScreenTrainerDetail extends ConsumerWidget {
     );
   }
 
-  Widget buildAppBar(BuildContext context) {
+  Widget buildAppBar(BuildContext context, String trainerToken) {
     return SliverAppBar(
       backgroundColor: FColors.black,
       expandedHeight: FDimen.trainerDetailExpandedHeight,
@@ -48,13 +49,9 @@ class ScreenTrainerDetail extends ConsumerWidget {
       actions: [
         Padding(
             padding: const EdgeInsets.only(right: 10, top: 10),
-            child: InkWell(
-              onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (context) => const ScreenEditTrainerDetail())),
-              child: const Icon(FitQaIcon.modification),
-            ))
+            child: trainerToken.isEmpty
+                ? _buildFavoriteAction()
+                : _buildModifyAction(context))
       ],
       centerTitle: false,
       flexibleSpace: const TrainerFlexibleSpace(),
@@ -78,6 +75,19 @@ class ScreenTrainerDetail extends ConsumerWidget {
 
   Widget _buildLoading() => const SliverToBoxAdapter(
       child: Center(child: CircularProgressIndicator()));
+
+  Widget _buildModifyAction(BuildContext context) => InkWell(
+        onTap: () => Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (context) => const ScreenEditTrainerDetail())),
+        child: const Icon(FitQaIcon.modification),
+      );
+
+  Widget _buildFavoriteAction() => InkWell(
+        onTap: () => {},
+        child: const Icon(FitQaIcon.star),
+      );
 
   Widget buildFeedbackListView() => const SliverFillRemaining(
       hasScrollBody: true, child: TrainerFeedbackTab());

--- a/fitqa_flutter/lib/src/presentation/widgets/feedback/detail/section_feedback_answer.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/feedback/detail/section_feedback_answer.dart
@@ -1,20 +1,20 @@
 import 'package:fitqa/src/application/feedback/feedback_detail.dart';
+import 'package:fitqa/src/application/storage/trainer_token_facade.dart';
 import 'package:fitqa/src/presentation/widgets/feedback/detail/section_feedback_answer_other.dart';
 import 'package:fitqa/src/presentation/widgets/feedback/detail/section_feedback_answer_owner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class SectionFeedbackAnswer extends ConsumerWidget {
-  final ownerTrainerToken = "trn_hQReCtwl9OW9srhO";
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final feedbackDetail = ref.watch(feedbackDetailProvider).data!;
+    final ownerTrainerToken = ref.watch(trainerTokenProvider);
 
     // 답변을 해야되는 경우. (트레이너 지정되고, 아직 답변 안했을때.
     if (ownerTrainerToken == feedbackDetail.trainer.trainerToken &&
         feedbackDetail.answer == null) return SectionFeedbackAnswerOwner();
 
-    return SectionFeedbackAnswerOther();
+    return const SectionFeedbackAnswerOther();
   }
 }


### PR DESCRIPTION
### 기존 문제상황
`ownerUserToken`, `ownerTrainerToken` 에 따라 변경되는 UI가 반영되지 않은 부분을 업데이트 했습니다

### 변경 내용
- [x] 마이페이지, 트레이너 디테일, 피드백 디테일, 홈 화면을 수정

**마이 페이지** // 유저 -> 유저페이지, 트레이너 -> 트레이너페이지, 로그인 페이지
```dart
  @override
  Widget build(BuildContext context, WidgetRef ref) {
    final ownerTrainerToken = ref.watch(trainerTokenProvider);
    final ownerUserToken = ref.watch(userTokenProvider);
    final trainerDetailTokenController =
        ref.watch(selectedTrainerTokenProvider.notifier);

    if (ownerUserToken.isEmpty && ownerTrainerToken.isEmpty) {
      return _buildLoginPage();
    } else if (ownerUserToken.isNotEmpty) {
      return _buildUserMyPage();
    } else {
      return _buildTrainerMyPage(
          trainerDetailTokenController, ownerTrainerToken);
    }
  }
```
**트레이너 디테일** -> 트레이너 사용자인지에 따라 수정 / 즐겨찾기
```dart
            child: trainerToken.isEmpty
                ? _buildFavoriteAction()
                : _buildModifyAction(context))
```
**트레이너 답변 페이지** -> 트레이너 사용자일 때 트레이너 피드백일 경우

**홈 페이지** -> 유저 사용자가 아닐 때에는 `FAB` 비활성화