### PR TITLE
Scroll down when click feedback list in trainer detail

### DIFF
--- a/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
+++ b/fitqa_flutter/lib/src/presentation/screens/screen_trainer_detail.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:fitqa/src/application/storage/trainer_token_facade.dart';
 import 'package:fitqa/src/application/trainer/trainer_detail.dart';
 import 'package:fitqa/src/common/fitqa_icon.dart';
@@ -14,6 +16,9 @@ import 'package:fitqa/src/theme/dimen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+final trainerDetailScrollController =
+    StateProvider<ScrollController>((ref) => ScrollController());
+
 class ScreenTrainerDetail extends ConsumerWidget {
   const ScreenTrainerDetail({Key? key}) : super(key: key);
 
@@ -21,8 +26,11 @@ class ScreenTrainerDetail extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final trainerDetail = ref.watch(trainerDetailProvider);
     final ownerTrainerToken = ref.watch(trainerTokenProvider);
+    final scrollController = ref.watch(trainerDetailScrollController);
+
     return Scaffold(
       body: CustomScrollView(
+        controller: scrollController,
         slivers: trainerDetail.maybeWhen(
             orElse: () => [_buildLoading()],
             success: (_) => [

--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_feedback_action.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_feedback_action.dart
@@ -1,6 +1,7 @@
 import 'package:fitqa/src/application/trainer/trainer_detail.dart';
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/presentation/screens/screen_feedback_request.dart';
+import 'package:fitqa/src/presentation/screens/screen_trainer_detail.dart';
 import 'package:fitqa/src/theme/color.dart';
 import 'package:fitqa/src/theme/dimen.dart';
 import 'package:flutter/material.dart';
@@ -12,7 +13,11 @@ class TrainerFeedbackAction extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final trainerDetail = ref.watch(trainerDetailProvider).data!;
-
+    final scrollController = ref.watch(trainerDetailScrollController);
+    // FIXME(in.heo)
+    // - hard-coded value
+    // - 답변 내역까지 콘텐츠의 양에 따라 이동해야 되는데
+    final scrollAmount = MediaQuery.of(context).size.height * 2;
     return Card(
         child: SizedBox(
       height: FDimen.trainerDetailFeedbackRequesterSize,
@@ -56,7 +61,7 @@ class TrainerFeedbackAction extends ConsumerWidget {
             child: ListTile(
               title: RichText(
                   text: TextSpan(
-                      text: "답변하기",
+                      text: "답변내역",
                       style:
                           const TextStyle(fontSize: 18, color: FColors.black),
                       children: [
@@ -68,10 +73,8 @@ class TrainerFeedbackAction extends ConsumerWidget {
                             color: FColors.blue))
                   ])),
               trailing: const Icon(FitQaIcon.enter),
-              onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (context) => ScreenFeedbackRequest())),
+              onTap: () => scrollController.animateTo(scrollAmount,
+                  duration: const Duration(seconds: 1), curve: Curves.easeOut),
             ),
           ),
         ],


### PR DESCRIPTION
### 변경 내용
![image](https://user-images.githubusercontent.com/50590025/164043422-5a780caa-0bd0-46fa-9a68-07ed0e44989d.png)
답변 내역을 누를 시 답변 내역으로 이동하는 스크롤을 추가
 - 콘텐츠의 양에 따라 이동하게 재 수정 필요
 - 현재는 하드 코딩 값만큼 내려가도록 작성

```dart
    final scrollController = ref.watch(trainerDetailScrollController);
    // FIXME(in.heo)
    // - hard-coded value
    // - 답변 내역까지 콘텐츠의 양에 따라 이동해야 되는데
    final scrollAmount = MediaQuery.of(context).size.height * 2;
```