### PR TITLE
Feat: add trainer selection on trainer detail screen

### DIFF
--- a/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_feedback_action.dart
+++ b/fitqa_flutter/lib/src/presentation/widgets/trainer/detail/trainer_feedback_action.dart
@@ -1,3 +1,4 @@
+import 'package:fitqa/src/application/feedback/feedback_selected_trainer.dart';
 import 'package:fitqa/src/application/trainer/trainer_detail.dart';
 import 'package:fitqa/src/common/fitqa_icon.dart';
 import 'package:fitqa/src/presentation/screens/screen_feedback_request.dart';
@@ -13,6 +14,9 @@ class TrainerFeedbackAction extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final trainerDetail = ref.watch(trainerDetailProvider).data!;
+
+    final selectedTrainerController =
+        ref.watch(selectedTrainerProvider.notifier);
     final scrollController = ref.watch(trainerDetailScrollController);
     // FIXME(in.heo)
     // - hard-coded value
@@ -42,10 +46,13 @@ class TrainerFeedbackAction extends ConsumerWidget {
                             color: FColors.blue))
                   ])),
               trailing: const Icon(FitQaIcon.enter),
-              onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (context) => ScreenFeedbackRequest())),
+              onTap: () {
+                selectedTrainerController.state = trainerDetail;
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => ScreenFeedbackRequest()));
+              },
             ),
           ),
           const Divider(


### PR DESCRIPTION
### 기존 문제상황
- 트레이너 상세페이지에서 `상담하기`를 눌렀을때 트레이너가 선택 안된채로 피드백 등록 페이지가 나옴

### 변경 내용
- 트레이너 상세페이지에서 `상담하기` 누르면 트레이너 선택된 채로 피드백 등록 페이지가 나오도록 함

